### PR TITLE
Use BPHash functions directly

### DIFF
--- a/include/parallelzone/hasher.hpp
+++ b/include/parallelzone/hasher.hpp
@@ -11,23 +11,13 @@
 
 namespace pz {
 
-using Hasher    = bphash::Hasher;
-using HashValue = bphash::HashValue;
-using HashType  = bphash::HashType;
+using bphash::hash_to_string;
+using bphash::Hasher;
+using bphash::HashType;
+using bphash::HashValue;
+using bphash::make_hash;
 
 inline auto make_hasher() { return Hasher(HashType::Hash128); }
-
-/** @brief Return a string representation of a hash
- *
- * The string in lower case hex representation
- * with the length of 2*number_of_bits/8 characters.
- *
- * @param[in] hash The hash
- * @returns A string representing the hash
- */
-inline std::string hash_to_string(const HashValue& hash) {
-    return bphash::hash_to_string(hash);
-}
 
 /** @brief Generates a hash string in a single call
  *
@@ -43,22 +33,6 @@ auto hash_objects(Args&&... args) {
     auto h = make_hasher();
     h(std::forward<Args>(args)...);
     return bphash::hash_to_string(h.finalize());
-}
-
-/** @brief Generates a hash in a single call
- *
- * This can be used to easily obtain the hash of several objects at once
- * without creating a Hasher object manually.
- *
- * @tparam Args variadic template for types of input objects
- * @param[in] args Objects to hash
- * @returns 128 bit hash of the given object(s)
- */
-template<typename... Args>
-auto make_hash(Args&&... args) {
-    auto h = make_hasher();
-    h(std::forward<Args>(args)...);
-    return h.finalize();
 }
 
 } // namespace pz

--- a/tests/hasher.cpp
+++ b/tests/hasher.cpp
@@ -27,7 +27,7 @@ TEST_CASE("Hashing with BPHash") {
     auto rv            = std::ref(v);
     auto rs            = std::ref(sa);
 
-    REQUIRE(hash_objects(v) == hash_to_string(make_hash(v)));
+    REQUIRE(hash_objects(v) == hash_to_string(make_hash(HashType::Hash128, v)));
     REQUIRE(hash_objects(v) == hash_objects(std::vector<int>{1, 2, 3}));
     REQUIRE_FALSE(hash_objects(rv) == hash_objects(std::vector<int>{3, 2, 1}));
     // BPHash adds typeid to the hash when BPHASH_USE_TYPEID is defined.


### PR DESCRIPTION
This is related to the hash value changes in TA DistArray tests. 