### PR TITLE
Remove unused tables

### DIFF
--- a/.github/workflows/c-cpp.yaml
+++ b/.github/workflows/c-cpp.yaml
@@ -8,6 +8,6 @@ jobs:
   build:
     uses: NWChemEx-Project/.github/.github/workflows/c-cpp_tmpl.yaml@master
     with:
-      dependencies: 'gcc cmake openmpi'
+      dependencies: 'gcc gcovr cmake openmpi'
     secrets:
       CPP_GITHUB_TOKEN: ${{ secrets.CPP_GITHUB_TOKEN }}


### PR DESCRIPTION
This PR is primarily to see if pushing to master will trigger a rebuild of the docs. It also deletes the Sphinx indices on the TOC we weren't using.