### PR TITLE
Reorder CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,8 @@ cmaize_add_library(
     DEPENDS "${project_depends}"
 )
 
+cmaize_add_package(${PROJECT_NAME} NAMESPACE nwx::)
+
 # N.B. this is a no-op if BUILD_PYBIND11_PYBINDINGS is not turned on
 include(nwx_pybind11)
 nwx_add_pybind11_module(
@@ -175,5 +177,3 @@ if("${BUILD_CPPYY_PYBINDINGS}")
         NAMESPACES parallelzone
     )
 endif()
-
-cmaize_add_package(${PROJECT_NAME} NAMESPACE nwx::)


### PR DESCRIPTION
<!---
    This is a comment. So are other lines like it. No need to delete them
    before submitting your PR. If you need help on submitting a PR please
    see our tutorial at https://nwchemex-project.github.io/.github/resources/github/pull_request.html
--->

<!---
    As of 12/7/2022 GitHub does not allow multiple PR templates. Our solution
    is to create one master PR template for all use cases, please delete the
    use cases which are not relevant for your PR. Sorry about the extra step.
--->

<!---
    General PR Questions
    ====================
    Please answer all questions in this section for all PRs.
--->

**PR Type**
<!---
    Please check the corresponding box.

    "Breaking change" is a PR which will break existing user-facing code. These
    types of PRs must be discussed in advance. They may be very small, or very
    extensive PRs depending on the change.

    A "feature" is a PR which adds a major new capability, massively overhauls
    an existing feature, writes entirely new documentation pages, or optimizes
    an extensive algorithm. Features usually take at least a week to implement.

    A "patch" is a PR which touches relatively few lines of code. Patches
    usually address bugs, minor performance issues, typos, clarify
    documentation, etc. Most patches are ready to go in a day or two.
--->

- [ ] Breaking change
- [ ] Feature
- [x] Patch

**Brief Description**
<!---
    In a couple sentences, describe what this pull request will accomplish. If
    there is a corresponding issue please link to it with
    [closing words](
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-
        using-a-keyword)
    as appropriate. If the goal is more complicated than can be articulated in
    a few sentences, please first open an issue and explain it in detail
    there.
--->

This PR reorders the CMakeLists.txt so the `cmaize_add_package()` call comes before our `nwx_add_pybind11_module()` call. This ensures that the package's install paths and rpaths are set up correctly before creating the Python bindings library.
