### PR TITLE
Remove Duplicate Key in `.clang-format`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -77,7 +77,6 @@ IndentWrappedFunctionNames: false
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
 KeepEmptyLinesAtTheStartOfBlocks: false
-Language: Cpp
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
 MaxEmptyLinesToKeep: 1


### PR DESCRIPTION
**Description**
Apparently, newer versions of clang-format throw and error when a key is provided twice in `.clang-format.` This removes the duplicate language specification.