### PR TITLE
Logger Tweaks

### DIFF
--- a/src/parallelzone/logging/detail_/spdlog/spdlog.cpp
+++ b/src/parallelzone/logging/detail_/spdlog/spdlog.cpp
@@ -62,7 +62,7 @@ inline auto map_severity_levels(Logger::severity s) {
 // -----------------------------------------------------------------------------
 
 SpdlogPIMPL::SpdlogPIMPL(spdlog_type logger) : m_logger_(std::move(logger)) {
-    m_logger_.set_level(spdlog::level::trace);
+    m_logger_.set_level(spdlog::level::info);
 }
 
 SpdlogPIMPL::pimpl_ptr SpdlogPIMPL::clone_() const {

--- a/src/python/runtime/runtime_view.cpp
+++ b/src/python/runtime/runtime_view.cpp
@@ -31,7 +31,8 @@ void export_runtime_view(pybind11::module_& m) {
       .def("has_me", &RuntimeView::has_me)
       .def("my_resource_set", &RuntimeView::my_resource_set)
       .def("count", &RuntimeView::count)
-      .def("logger", &RuntimeView::logger)
+      .def("logger", &RuntimeView::logger,
+           pybind11::return_value_policy::reference_internal)
       .def("stack_callback", &RuntimeView::stack_callback)
       .def(pybind11::self == pybind11::self)
       .def(pybind11::self != pybind11::self);


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No

**Description**
By default we were logging everything (i.e., trace logging). Info logging is supposed to be the
default. This PR fixes that. This PR also fixes a bug where the Python bindings were getting back a copy of the logger from the `RuntimeView` instead of an alias.

**TODOs**
None. R2g.