### PR TITLE
Set Logger Severity to Trace for Tests

### DIFF
--- a/tests/cxx/unit_tests/parallelzone/logging/detail_/spdlog/spdlog.cpp
+++ b/tests/cxx/unit_tests/parallelzone/logging/detail_/spdlog/spdlog.cpp
@@ -40,6 +40,7 @@ TEST_CASE("SpdlogPIMPL") {
     std::string pattern = "[%n] [%l] %v";
     spdlog_log.set_pattern(pattern);
     SpdlogPIMPL ss_log(spdlog_log);
+    ss_log.set_severity(severity::trace);
 
     SECTION("clone") {
         auto p = ss_log.clone();

--- a/tests/cxx/unit_tests/parallelzone/logging/logger.cpp
+++ b/tests/cxx/unit_tests/parallelzone/logging/logger.cpp
@@ -44,6 +44,8 @@ TEST_CASE("Logger") {
     spdlog_log.set_pattern(pattern);
 
     Logger log(std::make_unique<pimpl_type>(spdlog_log));
+    log.set_severity(severity::trace);
+
     Logger null;
 
     SECTION("ctors") {


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
None

**Description**
Like the title says, sets the logging severity to "trace" for the tests.