### PR TITLE
Adds `profile` member function.

### DIFF
--- a/include/parallelzone/hardware/cpu/cpu.hpp
+++ b/include/parallelzone/hardware/cpu/cpu.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <parallelzone/task_wrapper.hpp>
+
+namespace parallelzone::hardware {
+
+struct ProfileInformation {};
+
+class CPU {};
+
+} // namespace parallelzone::hardware

--- a/include/parallelzone/hardware/cpu/cpu.hpp
+++ b/include/parallelzone/hardware/cpu/cpu.hpp
@@ -15,13 +15,81 @@
  */
 
 #pragma once
-
-#include <parallelzone/task_wrapper.hpp>
+#include <chrono>
+#include <parallelzone/task/task_wrapper.hpp>
 
 namespace parallelzone::hardware {
 
-struct ProfileInformation {};
+/** @brief Aggregates known profiling information.
+ *
+ *  The class is primarily intended to ensure that `profile_it` can maintain a
+ *  consistent API as new profiling information is added, i.e.,
+ *  `ProfileInformation` is intended to be an opaque type whose content can
+ *   grow over time.
+ */
+struct ProfileInformation {
+    /// Type used to measure time durations
+    using duration = std::chrono::high_resolution_clock::duration;
 
-class CPU {};
+    /// Long the function ran for
+    duration wall_time;
+};
+
+/** @brief Class representing a central processing unit (CPU).
+ *
+ *  This class is intended to be a runtime interface for interacting with the
+ *  CPU. Right now it can be used to profile a task run on a CPU.
+ */
+class CPU {
+private:
+    /// Type used internally for wrapping tasks
+    using task_type = task::TaskWrapper;
+
+    /// Type used internally for returning type-erased results
+    using result_type = typename task_type::type_erased_return_type;
+
+public:
+    /// Type containing profiling information
+    using profile_information = ProfileInformation;
+
+    /** @brief Profiles a function.
+     *
+     *  @tparam FxnType The type of the callable to profile.
+     *  @tparam Args The types of the arguments to forward to the callable.
+     *
+     *  @param[in] fxn The callable to run.
+     *  @param[in] args The arguments to forward to the callable.
+     *
+     *  @return A pair whose first element is the return of your callable and
+     *          the second element is the profiling information obtained from
+     *          running the callable. If your function does not have a return
+     *          only the profiling info is returned.
+     *
+     *  @throw ??? Throws if the callable throws. Same throw guarantee.
+     */
+    template<typename FxnType, typename... Args>
+    auto profile_it(FxnType&& fxn, Args&&... args) const {
+        auto&& [t, unwrapper] = task::make_task(std::forward<FxnType>(fxn),
+                                                std::forward<Args>(args)...);
+        auto result           = profile_it_(std::move(t));
+
+        using result_type = decltype(unwrapper(std::move(result.first)));
+
+        if constexpr(std::is_same_v<result_type, void>) {
+            return std::move(result.second);
+        } else {
+            auto unwrapped_result = unwrapper(std::move(result.first));
+            return std::make_pair(std::move(unwrapped_result),
+                                  std::move(result.second));
+        }
+    }
+
+private:
+    /// How the type-erased profile_it_ method returns its results
+    using profile_return_type = std::pair<result_type, profile_information>;
+
+    /// Returns the result of the task and the profiling information obtained
+    profile_return_type profile_it_(task_type&& task) const;
+};
 
 } // namespace parallelzone::hardware

--- a/include/parallelzone/hardware/hardware.hpp
+++ b/include/parallelzone/hardware/hardware.hpp
@@ -1,0 +1,3 @@
+#pragma once
+#include <parallelzone/hardware/cpu/cpu.hpp>
+#include <parallelzone/hardware/ram/ram.hpp>

--- a/include/parallelzone/logging/logging.hpp
+++ b/include/parallelzone/logging/logging.hpp
@@ -1,0 +1,3 @@
+#pragma once
+#include <parallelzone/logging/logger.hpp>
+#include <parallelzone/logging/logger_factory.hpp>

--- a/include/parallelzone/parallelzone.hpp
+++ b/include/parallelzone/parallelzone.hpp
@@ -23,7 +23,10 @@
  * library.
  */
 
-#include "parallelzone/serialization.hpp"
+#include <parallelzone/hardware/hardware.hpp>
+#include <parallelzone/logging/logging.hpp>
 #include <parallelzone/runtime/runtime.hpp>
+#include <parallelzone/serialization.hpp>
+#include <parallelzone/task/task.hpp>
 
 namespace parallelzone {} // namespace parallelzone

--- a/include/parallelzone/task/argument_traits.hpp
+++ b/include/parallelzone/task/argument_traits.hpp
@@ -1,0 +1,53 @@
+#pragma once
+#include <type_traits>
+
+namespace parallelzone::task {
+
+/** @brief Structure that works out cv-qualifiers and reference-ness of @p T.
+ *
+ *  @tparam The type being inspected.
+ *
+ *  This structure is predominantly intended for use in template contexts where
+ *  the properties of a type are not known. In those contexts, it can be
+ *  useful to know if a type @p T is a reference, a const reference etc.
+ */
+template<typename T>
+struct ArgumentTraits {
+    /// Type of @p T w/o reference and cv-qualifiers
+    using value_type = std::decay_t<T>;
+
+    /// Type of a mutable reference to an object of type @p value_type
+    using reference = value_type&;
+
+    /// Type of a read-only reference to an object of type @p value_type
+    using const_reference = const value_type&;
+
+    /// Type of an rvalue reference to an object of type @p value_type
+    using rvalue_reference = value_type&&;
+
+    /// Type of a pointer to an object of type @p value_type
+    using pointer = value_type*;
+
+    /// Type of a pointer to a read-only object of type @p value_type
+    using const_pointer = const value_type*;
+
+    /// Is @p T consistent with being passed by value?
+    static constexpr bool is_value_v = std::is_same_v<value_type, T>;
+
+    /// Is @p T consistent with being passed as a const value?
+    static constexpr bool is_const_value_v =
+      std::is_same_v<const value_type, T>;
+
+    /// Is @p T consistent with being passed by reference?
+    static constexpr bool is_reference_v = std::is_same_v<reference, T>;
+
+    /// Is @p T consistent with being passed by const reference?
+    static constexpr bool is_const_reference_v =
+      std::is_same_v<const_reference, T>;
+
+    /// Is @p T consistent with being passed by rvalue reference?
+    static constexpr bool is_rvalue_reference_v =
+      std::is_same_v<rvalue_reference, T>;
+};
+
+} // namespace parallelzone::task

--- a/include/parallelzone/task/argument_wrapper.hpp
+++ b/include/parallelzone/task/argument_wrapper.hpp
@@ -1,0 +1,111 @@
+#pragma once
+#include <parallelzone/task/argument_traits.hpp>
+
+namespace parallelzone::task {
+
+/** @brief Class to help forward arguments for generic functions.
+ *
+ *  @tparam The type of the object *this will wrap.
+ *
+ *  Depending on how the user passes an argument to a function, the function
+ *  will own the value or alias it. ParallelZone is designed to generically
+ *  interact with functions and in turn will need to capture arguments. When
+ *  PZ captures an argument it will need to prolong the lifetime if the user
+ *  passed the argument by value or rvalue reference, and maintain the aliasing
+ *  if the user passed the argument by reference.
+ *
+ *  The ArgumentWrapper class handles the logic of potentially prolonging the
+ *  lifetime of the argument, while providing a consistent API regardless of
+ *  whether or not it is owning or aliasing the argument.
+ */
+template<typename T>
+class ArgumentWrapper {
+private:
+    /// Is @p U the same type as *this?
+    template<typename U>
+    static constexpr bool is_arg_wrapper_v =
+      std::is_same_v<ArgumentWrapper<T>, U>;
+
+    /// Disables a template function if @p U is the same type as *this
+    template<typename U>
+    using disable_if_arg_wrapper = std::enable_if_t<!is_arg_wrapper_v<U>>;
+
+public:
+    /// Type traits of @p T needed for TMP
+    using traits_t = ArgumentTraits<T>;
+
+    /// Unqualified type of @p T
+    using value_type = typename traits_t::value_type;
+
+    /// Type of a mutable reference to an object of type @p value_type
+    using reference = typename traits_t::reference;
+
+    /// Type of a read-only reference to an object of type @p value_type
+    using const_reference = typename traits_t::const_reference;
+
+    /** @brief Creates a new object which wraps @p object.
+     *
+     *  @tparam U The type of object must be implicitly convertible to @p T.
+     *  @tparam <anonymous> Used to disable this ctor via SFINAE if @p U is
+     *                      an object of type ArgumentWrapper.
+     *
+     *  The value ctor wraps the provided argument, automatically prolonging
+     *  its lifetime if needed (needed when @p T is a value or rvalue
+     *  reference). If an extended lifetime is not needed, @p object will be
+     *  aliased and the user is responsible for ensuring @p object is alive
+     *  for the duration of *this.
+     *
+     *  @param object The value *this is wrapping.
+     *
+     *  @throw None No throw guarantee.
+     */
+    template<typename U, typename = disable_if_arg_wrapper<std::decay_t<U>>>
+    explicit ArgumentWrapper(U&& object) : m_value_(std::forward<U>(object)) {}
+
+    /** @brief Provides potentially mutable access to the value.
+     *
+     *  This method is used to access the value. The result will be mutable if
+     *  @p T is not const-qualified and read-only if @p T is const-qualified.
+     *
+     *  @return A reference to the wrapped value.
+     *
+     *  @throw None No throw guarantee.
+     */
+    auto& value() { return m_value_; }
+
+    /** @brief Provides read-only access to the value.
+     *
+     *  This method is identical to the non-const version except that the result
+     *  is guarantee to be read-only.
+     *
+     *  @return A read-only reference to the wrapped value.
+     *
+     *  @throw None No throw guarantee.
+     */
+    const auto& value() const { return m_value_; }
+
+private:
+    /// Hold by value?
+    static constexpr bool hold_by_value =
+      traits_t::is_value_v || traits_t::is_rvalue_reference_v;
+
+    /// Hold by reference?
+    static constexpr bool hold_by_reference = traits_t::is_reference_v;
+
+    /// Hold by const reference?
+    static constexpr bool hold_by_const_reference =
+      traits_t::is_const_reference_v;
+
+    /// Type, if being held by reference
+    using reference_holder =
+      std::conditional_t<hold_by_reference, reference, const_reference>;
+
+    /// Works out the type of the holder
+    using holder_type =
+      std::conditional_t<hold_by_value, value_type, reference_holder>;
+
+    /// The actual value being held.
+    holder_type m_value_;
+};
+
+} // namespace parallelzone::task

--- a/include/parallelzone/task/detail_/task_wrapper_.hpp
+++ b/include/parallelzone/task/detail_/task_wrapper_.hpp
@@ -1,0 +1,83 @@
+#pragma once
+#include <any>
+#include <parallelzone/task/argument_wrapper.hpp>
+#include <tuple>
+namespace parallelzone::task::detail_ {
+
+/** @brief Creates a tuple that will forward arguments.
+ *
+ *  @tparams Args The types of @p args
+ *
+ *  In order to store arguments we need to put them in ArgumentWrapper objects
+ *  (which will manage the lifetime). This function forwards a parameter pack
+ *  into a tuple of ArgumentWrapper objects.
+ *
+ *  @param[in] args The arguments to wrap into a tuple.
+ *
+ *  @throw None No throw guarantee.
+ */
+template<typename... Args>
+static auto wrap_args_(Args&&... args) {
+    return std::tuple{ArgumentWrapper<Args>(std::forward<Args>(args))...};
+}
+
+/// Implements apply_ by expanding tuple. See other overload
+template<typename FxnType, typename... Args, std::size_t... I>
+static auto apply_(FxnType&& fxn, std::tuple<ArgumentWrapper<Args>...> args,
+                   std::index_sequence<I...>) {
+    return fxn(std::forward<Args>(std::get<I>(args).value())...);
+}
+
+/** @brief Calls a callable with the provided arguments.
+ *
+ *  @tparam FxnType The type of the callable.
+ *  @tparam Args The types of the arguments as the user wants them to be passed.
+ *
+ *  Most functions expect positional arguments and not a tuple of arguments,
+ *  but tuples are more convenient for meta-programming. This function will
+ *  take a tuple and unpack it into the positional arguments of the provided
+ *  function, and then call the function.
+ *
+ *  @note This function reimplements std::apply because we need to additionally
+ *         call `.value()` on each element of the tuple.
+ *
+ *  @param[in] fxn The callable to call.
+ *  @param[in] args A tuple containing the arguments to forward to @p fxn.
+ *
+ *  @return Returns if @p fxn returns.
+ *
+ *  @throws Throws if @p fxn throws. Same throw guarantee.
+ */
+template<typename FxnType, typename... Args>
+static auto apply_(FxnType&& fxn, std::tuple<ArgumentWrapper<Args>...> args) {
+    return apply_(std::forward<FxnType>(fxn), std::move(args),
+                  std::make_index_sequence<sizeof...(Args)>());
+}
+
+template<typename FxnType, typename... Args>
+static auto make_inner_lambda_(FxnType&& fxn, Args&&... args) {
+    return [fxn  = std::forward<FxnType>(fxn),
+            args = wrap_args_(std::forward<Args>(args)...)]() {
+        apply_(fxn, std::move(args));
+    };
+}
+
+template<typename FxnType, typename... Args>
+static auto make_outer_lambda_(FxnType&& fxn, Args&&... args) {
+    auto inner_lambda = make_inner_lambda_(std::forward<FxnType>(fxn),
+                                           std::forward<Args>(args)...);
+
+    using result_type = decltype(inner_lambda());
+    if constexpr(std::is_same_v<result_type, void>) {
+        return [inner_lambda = std::move(inner_lambda)]() {
+            inner_lambda();
+            return std::any{};
+        };
+    } else {
+        return [inner_lambda = std::move(inner_lambda)]() {
+            return std::make_any<result_type>(inner_lambda());
+        };
+    }
+}
+
+} // namespace parallelzone::task::detail_

--- a/include/parallelzone/task/detail_/task_wrapper_.hpp
+++ b/include/parallelzone/task/detail_/task_wrapper_.hpp
@@ -97,6 +97,25 @@ auto make_inner_lambda_(FxnType&& fxn, Args&&... args) {
     return l;
 }
 
+/** @brief Wraps the process of type-erasing a lazy function call.
+ *
+ *  @tparam FxnType The type of the callable.
+ *  @tparam Args The types of the arguments to forward to the function.
+ *
+ *  This is the top-level function implementing the type-erasure of lazily
+ *  executing a call. It relies on `make_inner_lambda_` to create the lambda
+ *  capable of lazily running the call. The lambda from make_inner_lambda_ still
+ *  retains the return type, which is what the lambda from this function
+ *  erases. The lambda resulting from this function has the signature
+ *  `std::any lambda();`.
+ *
+ *  @param[in] fxn The callable to wrap.
+ *  @param[in] args The arguments to pass to the callable when it is executed.
+ *
+ *  @return A type-erased callable, that when run will execute @p fxn.
+ *
+ *  @throw None No throw guarantee.
+ */
 template<typename FxnType, typename... Args>
 static auto make_outer_lambda_(FxnType&& fxn, Args&&... args) {
     auto inner_lambda = make_inner_lambda_(std::forward<FxnType>(fxn),

--- a/include/parallelzone/task/task.hpp
+++ b/include/parallelzone/task/task.hpp
@@ -1,0 +1,3 @@
+#pragma once
+#include <parallelzone/task/argument_wrapper.hpp>
+#include <parallelzone/task/task_wrapper.hpp>

--- a/include/parallelzone/task/task_wrapper.hpp
+++ b/include/parallelzone/task/task_wrapper.hpp
@@ -16,6 +16,7 @@
 
 #pragma once
 #include <any>
+#include <functional>
 #include <parallelzone/task/detail_/task_wrapper_.hpp>
 
 namespace parallelzone::task {

--- a/include/parallelzone/task/task_wrapper.hpp
+++ b/include/parallelzone/task/task_wrapper.hpp
@@ -1,0 +1,84 @@
+#pragma once
+#include <any>
+#include <parallelzone/task/detail_/task_wrapper_.hpp>
+
+namespace parallelzone::task {
+
+/** @brief Infrastructure for type-erasing a task.
+ *
+ *  A lot of ParallelZone revolves around scheduling, running, and measuring
+ *  "tasks". To PZ, a task is nothing more than a call to a callable. The
+ *  callable may or may not return something and it may have side-effects (e.g.,
+ *  logging). The TaskWrapper class provides a generic type-erased interface for
+ *  interacting with the task.
+ *
+ *  @code
+ *  // Say you want to call function foo with arguments arg0, arg1. Then the
+ *  // usage is:
+ *  auto [task, unwrapper] = make_task(foo, arg0, arg1);
+ *
+ *  // Run the task
+ *  auto result = task();
+ *
+ *  // Get the result
+ *  auto unwrapped_result = unwrapper(result);
+ *  @endcode
+ *
+ *  It should be noted that wrapping functions with zero arguments is also
+ *  possible, just pass the name of the function to make_task. You can
+ *
+ */
+class TaskWrapper {
+private:
+public:
+    /// TMP for working out the result of the task
+    template<typename FxnType, typename... Args>
+    using return_type =
+      decltype(std::declval<FxnType>()(std::declval<Args>()...));
+
+    /// Type used to return the results of the task
+    using type_erased_return_type = std::any;
+
+    template<typename FxnType, typename... Args>
+    TaskWrapper(FxnType&& fxn, Args&&... args) :
+      m_erased_function_(detail_::make_outer_lambda_(
+        std::forward<FxnType>(fxn), std::forward<Args>(args)...)) {}
+
+    type_erased_return_type operator()() { return m_erased_function_(); }
+
+    /** @brief Creates a function which can unwrap a type-erased result.
+     *
+     *  The resulting function takes an rvalue reference to the type-erased
+     *  result (i.e., you'll probably need to move the result into the function)
+     *  and will return the object that was inside the type-erased, not a copy
+     *  or reference. In turn you should NOT use the type-erased result again
+     *  after calling the function.
+     */
+    template<typename ReturnType>
+    static auto unwrapper() {
+        return [](type_erased_return_type&& returned_object) {
+            if constexpr(std::is_same_v<ReturnType, void>) {
+                return;
+            } else {
+                return std::any_cast<ReturnType>(std::move(returned_object));
+            }
+        };
+    }
+
+private:
+    /// Type *this will use to hold the task
+    using erased_function_type = std::function<type_erased_return_type()>;
+
+    /// Type type-erased task
+    erased_function_type m_erased_function_;
+};
+
+template<typename FxnType, typename... Args>
+auto make_task(FxnType&& fxn, Args&&... args) {
+    using return_type = TaskWrapper::return_type<FxnType, Args...>;
+    auto unwrapper    = TaskWrapper::unwrapper<return_type>();
+    TaskWrapper t(std::forward<FxnType>(fxn), std::forward<Args>(args)...);
+    return std::make_pair(std::move(t), std::move(unwrapper));
+}
+
+} // namespace parallelzone::task

--- a/include/parallelzone/task/task_wrapper.hpp
+++ b/include/parallelzone/task/task_wrapper.hpp
@@ -23,7 +23,7 @@ namespace parallelzone::task {
 /** @brief Infrastructure for type-erasing a task.
  *
  *  A lot of ParallelZone revolves around scheduling, running, and measuring
- *  "tasks". To PZ, a task is nothing more than a call to a callable. The
+ *  "tasks". To PZ, a task is nothing more than executing a callable. The
  *  callable may or may not return something and it may have side-effects (e.g.,
  *  logging). The TaskWrapper class provides a generic type-erased interface for
  *  interacting with the task.
@@ -46,29 +46,110 @@ namespace parallelzone::task {
  */
 class TaskWrapper {
 private:
-public:
-    /// TMP for working out the result of the task
-    template<typename FxnType, typename... Args>
-    using return_type =
-      decltype(std::declval<FxnType>()(std::declval<Args>()...));
+    /// Is type @p U the same as TaskWrapper?
+    template<typename U>
+    static constexpr bool is_task_wrapper_v = std::is_same_v<U, TaskWrapper>;
 
+    /// Disables a method via SFINAE if @p U is TaskWrapper
+    template<typename U>
+    using disable_if_task_wrapper_t = std::enable_if_t<!is_task_wrapper_v<U>>;
+
+public:
     /// Type used to return the results of the task
     using type_erased_return_type = std::any;
 
-    template<typename FxnType, typename... Args>
-    TaskWrapper(FxnType&& fxn, Args&&... args) :
+    /** @brief Value ctor. Creates a TaskWrapper given a callable and arguments.
+     *
+     *  @tparam FxnType The type of the callable *this will wrap.
+     *  @tparam Args The types of the arguments to forward to the wrapped
+     *               callable.
+     *  @tparam <anonymous> Used to disable this method via SFINAE if
+     *                      @p FxnType is TaskWrapper.
+     *
+     *  Users are encouraged to rely on the `make_task` free function for
+     *  creating TaskWrapper objects. That freed function relies on this ctor.
+     *  This ctor will create a TensorWrapper object which wraps the provided
+     *  callable, @p fxn, and the arguments to pass to @p fxn, @p args. When
+     *  *this is executed via `operator()()` @p args will be forwarded to
+     *  @p fxn and the result returned as an object of type
+     *  @p type_erased_return_type.
+     *
+     *  @param[in] fxn The callable object this will wrap.
+     *  @param[in] args The arguments to forward to @p fxn when *this is
+     *                  executed.
+     *
+     *  @throw ??? Function may throw if capturing @p fxn or @p args throws.
+     *             This should be very unlikely though as captures are typically
+     *             by reference. Strong throw guarantee.
+     */
+    template<typename FxnType, typename... Args,
+             typename = disable_if_task_wrapper_t<std::decay_t<FxnType>>>
+    explicit TaskWrapper(FxnType&& fxn, Args&&... args) :
       m_erased_function_(detail_::make_outer_lambda_(
         std::forward<FxnType>(fxn), std::forward<Args>(args)...)) {}
 
+    /** @brief Takes ownership of another task.
+     *
+     *  This method will transfer the task wrapped by a different TaskWrapper
+     *  object into *this. The TaskWrapper that *this takes the object from
+     *  will no longer own the task and is in a valid, but otherwise unspecified
+     *  state.
+     *
+     *  @param[in,out] other The object to take the task from. After this
+     *                       operation @p other is in a valid, but otherwise
+     *                       unspecified state.
+     *
+     *  @throw None No throw guarantee.
+     */
+    TaskWrapper(TaskWrapper&& other) noexcept = default;
+
+    /** @brief Overrides the task in *this with that in @p rhs.
+     *
+     *  This method will release the task currently wrapped by *this and
+     *  replace it with the task wrapped by @p rhs. The task is taken from
+     *  @p rhs so that *this owns it and @p rhs no longer does. After this
+     *  operation @p rhs is in a valid, but otherwise unspecified state.
+     *
+     *  @param[in,out] rhs The object to take the task from. After this
+     *                     operation @p rhs is in a valid, but otherwise
+     *                     unspecified state.
+     *
+     *  @return *this after overriding the task.
+     *
+     *  @throw None no throw guarantee.
+     */
+    TaskWrapper& operator=(TaskWrapper&& rhs) noexcept = default;
+
+    /** @brief Runs the task held by *this.
+     *
+     *  TaskWrapper objects allow lazy execution the wrapped task. Calling this
+     *  method will execute the task. Generally speaking, tasks are single use,
+     *  so this function should only be called once. The TaskWrapper class does
+     *  NOT enforce this because without knowledge of the wrapped function's
+     *  implementation it can not know for sure whether this is the case or
+     *  not.
+     *
+     *  @return A type erased return. If the wrapped function does not return,
+     *          the resulting object should NOT be unwrapped.
+     *
+     *  @throw ??? Throws if the wrapped function throws. Same throw guarantee.
+     */
     type_erased_return_type operator()() { return m_erased_function_(); }
 
     /** @brief Creates a function which can unwrap a type-erased result.
      *
-     *  The resulting function takes an rvalue reference to the type-erased
-     *  result (i.e., you'll probably need to move the result into the function)
-     *  and will return the object that was inside the type-erased, not a copy
-     *  or reference. In turn you should NOT use the type-erased result again
-     *  after calling the function.
+     *  @tparam ReturnType The type to unwrap the object as.
+     *
+     *  This function creates a callable that takes an rvalue reference to a
+     *  @p type_erased_return_type object and returns the object that was
+     *  inside the object. Note that the return from the callable is the object,
+     *  not a copy or reference. In turn the object passed to the callable is
+     *  consumed and should NOT be used again.
+     *
+     *  @return A callable capable of unwrapping a @p type_erased_return_type
+     *          object into a @p ReturnType object.
+     *
+     *  @throw None No throw guarantee.
      */
     template<typename ReturnType>
     static auto unwrapper() {
@@ -82,6 +163,10 @@ public:
     }
 
 private:
+    /// Deleted because there can only be one instance of a task.
+    TaskWrapper(const TaskWrapper&)            = delete;
+    TaskWrapper& operator=(const TaskWrapper&) = delete;
+
     /// Type *this will use to hold the task
     using erased_function_type = std::function<type_erased_return_type()>;
 
@@ -89,10 +174,36 @@ private:
     erased_function_type m_erased_function_;
 };
 
+/** @brief Wraps a task in a TaskWrapper object.
+ *
+ *  @related TaskWrapper
+ *
+ *  @tparam FxnType The type of the callable that *this will wrap.
+ *  @tparam Args The types of the arguments that will be forwarded to the
+ *               callable.
+ *
+ *  To interact generically with a task, ParallelZone requires the task to be
+ *  wrapped in a TaskWrapper object. When a TaskWrapper object executes its
+ *  task the results of the task, if any, are type-erased too. To restore
+ *  their types TaskWrapper objects can generate unwrapping callables. While
+ *  TaskWrapper objects and unwrapping callables can be made directly through
+ *  the TaskWrapper API, the resulting calls are template-heavy. This free
+ *  function relies on a little bit of under-the-hood template meta-programming
+ *  to take care of the templating for the caller, thus providing a nicer API.
+ *
+ *  @param[in] fxn The callable to wrap.
+ *  @param[in] args The arguments to forward to @p fxn.
+ *
+ *  @return The task and a callable for unwrapping the result of the task.
+ *
+ *  @throw ??? This function may throw if capturing the arguments throws. This
+ *             should be a very unlikely occurrence. Strong throw guarantee.
+ */
 template<typename FxnType, typename... Args>
 auto make_task(FxnType&& fxn, Args&&... args) {
-    using return_type = TaskWrapper::return_type<FxnType, Args...>;
-    auto unwrapper    = TaskWrapper::unwrapper<return_type>();
+    using return_type =
+      decltype(std::declval<FxnType>()(std::declval<Args>()...));
+    auto unwrapper = TaskWrapper::unwrapper<return_type>();
     TaskWrapper t(std::forward<FxnType>(fxn), std::forward<Args>(args)...);
     return std::make_pair(std::move(t), std::move(unwrapper));
 }

--- a/src/parallelzone/hardware/cpu/cpu.cpp
+++ b/src/parallelzone/hardware/cpu/cpu.cpp
@@ -1,0 +1,14 @@
+#include <parallelzone/hardware/cpu/cpu.hpp>
+
+namespace parallelzone::hardware {
+
+typename CPU::profile_return_type CPU::profile_it_(task_type&& task) const {
+    profile_information i;
+    const auto t1 = std::chrono::high_resolution_clock::now();
+    auto result   = task();
+    const auto t2 = std::chrono::high_resolution_clock::now();
+    i.wall_time   = (t2 - t1);
+    return std::make_pair(std::move(result), std::move(i));
+}
+
+} // namespace parallelzone::hardware

--- a/tests/cxx/unit_tests/parallelzone/hardware/cpu/cpu.cpp
+++ b/tests/cxx/unit_tests/parallelzone/hardware/cpu/cpu.cpp
@@ -39,7 +39,7 @@ TEST_CASE("CPU") {
         SECTION("Has return") {
             auto l = [pa_vector](vector_type v) {
                 REQUIRE(v.data() == pa_vector);
-                return std::move(v);
+                return v;
             };
 
             auto&& [rv, info] = defaulted.profile_it(l, std::move(a_vector));

--- a/tests/cxx/unit_tests/parallelzone/task/argument_traits.cpp
+++ b/tests/cxx/unit_tests/parallelzone/task/argument_traits.cpp
@@ -1,0 +1,108 @@
+#include "../catch.hpp"
+#include <iostream>
+#include <parallelzone/task/argument_traits.hpp>
+#include <vector>
+
+using namespace parallelzone::task;
+
+TEST_CASE("ArgumentTraits<T>") {
+    SECTION("value") {
+        using type     = int;
+        using traits_t = ArgumentTraits<type>;
+
+        STATIC_REQUIRE(std::is_same_v<typename traits_t::value_type, type>);
+        STATIC_REQUIRE(std::is_same_v<typename traits_t::reference, type&>);
+        STATIC_REQUIRE(
+          std::is_same_v<typename traits_t::const_reference, const type&>);
+        STATIC_REQUIRE(
+          std::is_same_v<typename traits_t::rvalue_reference, type&&>);
+        STATIC_REQUIRE(std::is_same_v<typename traits_t::pointer, type*>);
+        STATIC_REQUIRE(
+          std::is_same_v<typename traits_t::const_pointer, const type*>);
+        STATIC_REQUIRE(traits_t::is_value_v);
+        STATIC_REQUIRE_FALSE(traits_t::is_const_value_v);
+        STATIC_REQUIRE_FALSE(traits_t::is_reference_v);
+        STATIC_REQUIRE_FALSE(traits_t::is_const_reference_v);
+        STATIC_REQUIRE_FALSE(traits_t::is_rvalue_reference_v);
+    }
+
+    SECTION("const value") {
+        using type     = int;
+        using traits_t = ArgumentTraits<const type>;
+
+        STATIC_REQUIRE(std::is_same_v<typename traits_t::value_type, type>);
+        STATIC_REQUIRE(std::is_same_v<typename traits_t::reference, type&>);
+        STATIC_REQUIRE(
+          std::is_same_v<typename traits_t::const_reference, const type&>);
+        STATIC_REQUIRE(
+          std::is_same_v<typename traits_t::rvalue_reference, type&&>);
+        STATIC_REQUIRE(std::is_same_v<typename traits_t::pointer, type*>);
+        STATIC_REQUIRE(
+          std::is_same_v<typename traits_t::const_pointer, const type*>);
+        STATIC_REQUIRE_FALSE(traits_t::is_value_v);
+        STATIC_REQUIRE(traits_t::is_const_value_v);
+        STATIC_REQUIRE_FALSE(traits_t::is_reference_v);
+        STATIC_REQUIRE_FALSE(traits_t::is_const_reference_v);
+        STATIC_REQUIRE_FALSE(traits_t::is_rvalue_reference_v);
+    }
+
+    SECTION("reference") {
+        using type     = int;
+        using traits_t = ArgumentTraits<type&>;
+
+        STATIC_REQUIRE(std::is_same_v<typename traits_t::value_type, type>);
+        STATIC_REQUIRE(std::is_same_v<typename traits_t::reference, type&>);
+        STATIC_REQUIRE(
+          std::is_same_v<typename traits_t::const_reference, const type&>);
+        STATIC_REQUIRE(
+          std::is_same_v<typename traits_t::rvalue_reference, type&&>);
+        STATIC_REQUIRE(std::is_same_v<typename traits_t::pointer, type*>);
+        STATIC_REQUIRE(
+          std::is_same_v<typename traits_t::const_pointer, const type*>);
+        STATIC_REQUIRE_FALSE(traits_t::is_value_v);
+        STATIC_REQUIRE_FALSE(traits_t::is_const_value_v);
+        STATIC_REQUIRE(traits_t::is_reference_v);
+        STATIC_REQUIRE_FALSE(traits_t::is_const_reference_v);
+        STATIC_REQUIRE_FALSE(traits_t::is_rvalue_reference_v);
+    }
+
+    SECTION("const reference") {
+        using type     = int;
+        using traits_t = ArgumentTraits<const type&>;
+
+        STATIC_REQUIRE(std::is_same_v<typename traits_t::value_type, type>);
+        STATIC_REQUIRE(std::is_same_v<typename traits_t::reference, type&>);
+        STATIC_REQUIRE(
+          std::is_same_v<typename traits_t::const_reference, const type&>);
+        STATIC_REQUIRE(
+          std::is_same_v<typename traits_t::rvalue_reference, type&&>);
+        STATIC_REQUIRE(std::is_same_v<typename traits_t::pointer, type*>);
+        STATIC_REQUIRE(
+          std::is_same_v<typename traits_t::const_pointer, const type*>);
+        STATIC_REQUIRE_FALSE(traits_t::is_value_v);
+        STATIC_REQUIRE_FALSE(traits_t::is_const_value_v);
+        STATIC_REQUIRE_FALSE(traits_t::is_reference_v);
+        STATIC_REQUIRE(traits_t::is_const_reference_v);
+        STATIC_REQUIRE_FALSE(traits_t::is_rvalue_reference_v);
+    }
+
+    SECTION("rvalue reference") {
+        using type     = int;
+        using traits_t = ArgumentTraits<type&&>;
+
+        STATIC_REQUIRE(std::is_same_v<typename traits_t::value_type, type>);
+        STATIC_REQUIRE(std::is_same_v<typename traits_t::reference, type&>);
+        STATIC_REQUIRE(
+          std::is_same_v<typename traits_t::const_reference, const type&>);
+        STATIC_REQUIRE(
+          std::is_same_v<typename traits_t::rvalue_reference, type&&>);
+        STATIC_REQUIRE(std::is_same_v<typename traits_t::pointer, type*>);
+        STATIC_REQUIRE(
+          std::is_same_v<typename traits_t::const_pointer, const type*>);
+        STATIC_REQUIRE_FALSE(traits_t::is_value_v);
+        STATIC_REQUIRE_FALSE(traits_t::is_const_value_v);
+        STATIC_REQUIRE_FALSE(traits_t::is_reference_v);
+        STATIC_REQUIRE_FALSE(traits_t::is_const_reference_v);
+        STATIC_REQUIRE(traits_t::is_rvalue_reference_v);
+    }
+}

--- a/tests/cxx/unit_tests/parallelzone/task/argument_wrapper.cpp
+++ b/tests/cxx/unit_tests/parallelzone/task/argument_wrapper.cpp
@@ -1,0 +1,106 @@
+#include "../catch.hpp"
+#include <iostream>
+#include <parallelzone/task/argument_wrapper.hpp>
+#include <vector>
+
+using namespace parallelzone::task;
+
+TEST_CASE("ArgumentWrapper<T>") {
+    SECTION("Ctors") {
+        using T = std::vector<int>;
+        T value{1, 2, 3};
+
+        ArgumentWrapper<T> arg_wrapper(value);
+        auto pdata = arg_wrapper.value().data();
+        REQUIRE(arg_wrapper.value() == value);
+        REQUIRE(pdata != value.data());
+
+        SECTION("Copy ctor") {
+            ArgumentWrapper<T> copies(arg_wrapper);
+            REQUIRE(copies.value() == value);
+            REQUIRE(copies.value().data() != pdata);
+        }
+
+        SECTION("Move ctor") {
+            ArgumentWrapper<T> moves(std::move(arg_wrapper));
+            REQUIRE(moves.value() == value);
+            REQUIRE(moves.value().data() == pdata);
+        }
+
+        SECTION("Copy assignment") {
+            ArgumentWrapper<T> copies(T{7, 8, 9});
+            auto pcopies = &(copies = arg_wrapper);
+            REQUIRE(copies.value() == value);
+            REQUIRE(copies.value().data() != pdata);
+            REQUIRE(pcopies == &copies);
+        }
+
+        SECTION("Move assignment") {
+            ArgumentWrapper<T> moves(T{7, 8, 9});
+            auto pmoves = &(moves = std::move(arg_wrapper));
+            REQUIRE(moves.value() == value);
+            REQUIRE(moves.value().data() == pdata);
+            REQUIRE(pmoves == &moves);
+        }
+    }
+
+    SECTION("T == int") {
+        using T = int;
+        SECTION("By value") {
+            ArgumentWrapper<T> by_value(1);
+            REQUIRE(by_value.value() == 1);
+            REQUIRE(std::as_const(by_value).value() == 1);
+        }
+
+        SECTION("By reference") {
+            int value = 2;
+            ArgumentWrapper<T&> by_ref(value);
+            REQUIRE(&by_ref.value() == &value);
+            REQUIRE(&std::as_const(by_ref).value() == &value);
+        }
+
+        SECTION("By const reference") {
+            int value = 2;
+            ArgumentWrapper<const T&> by_cref(value);
+            REQUIRE(&by_cref.value() == &value);
+            REQUIRE(&std::as_const(by_cref).value() == &value);
+        }
+
+        SECTION("By rvalue reference") {
+            int value = 2;
+            ArgumentWrapper<T&&> by_rref(std::move(value));
+            REQUIRE(by_rref.value() == value);
+            REQUIRE(std::as_const(by_rref).value() == value);
+        }
+    }
+
+    SECTION("T == std::vector<int>") {
+        using T = std::vector<int>;
+        T value{1, 2, 3};
+
+        SECTION("By value") {
+            ArgumentWrapper<T> by_value(T{1, 2, 3});
+            REQUIRE(by_value.value() == value);
+            REQUIRE(std::as_const(by_value).value() == value);
+        }
+
+        SECTION("By reference") {
+            ArgumentWrapper<T&> by_ref(value);
+            REQUIRE(&by_ref.value() == &value);
+            REQUIRE(&std::as_const(by_ref).value() == &value);
+        }
+
+        SECTION("By const reference") {
+            ArgumentWrapper<const T&> by_cref(value);
+            REQUIRE(&by_cref.value() == &value);
+            REQUIRE(&std::as_const(by_cref).value() == &value);
+        }
+
+        SECTION("By rvalue reference") {
+            auto pvalue = value.data();
+            ArgumentWrapper<T&&> by_rref(std::move(value));
+            REQUIRE(by_rref.value().data() == pvalue);
+            REQUIRE(std::as_const(by_rref).value().data() == pvalue);
+        }
+    }
+}

--- a/tests/cxx/unit_tests/parallelzone/task/detail_/task_wrapper_.cpp
+++ b/tests/cxx/unit_tests/parallelzone/task/detail_/task_wrapper_.cpp
@@ -1,0 +1,200 @@
+#include "../../catch.hpp"
+#include <iostream>
+#include <parallelzone/task/detail_/task_wrapper_.hpp>
+#include <vector>
+
+using namespace parallelzone::task;
+
+namespace {
+
+using vector_type = std::vector<int>;
+
+} // namespace
+
+TEST_CASE("wrap_args_") {
+    int an_int = 1;
+    vector_type a_vector{1, 2, 3};
+    auto pa_vector = a_vector.data();
+
+    SECTION("No args") {
+        auto rv = detail_::wrap_args_();
+        REQUIRE(rv == std::make_tuple());
+    }
+
+    SECTION("by value") {
+        auto int_rv = detail_::wrap_args_(1);
+        REQUIRE(std::get<0>(int_rv).value() == 1);
+
+        auto vector_rv = detail_::wrap_args_(vector_type{1, 2, 3});
+        REQUIRE(std::get<0>(vector_rv).value() == a_vector);
+        REQUIRE(std::get<0>(vector_rv).value().data() != pa_vector);
+    }
+
+    SECTION("by reference") {
+        auto int_rv = detail_::wrap_args_(an_int);
+        REQUIRE(std::get<0>(int_rv).value() == 1);
+        REQUIRE(&std::get<0>(int_rv).value() == &an_int);
+
+        auto vector_rv = detail_::wrap_args_(a_vector);
+        REQUIRE(std::get<0>(vector_rv).value() == a_vector);
+        REQUIRE(&std::get<0>(vector_rv).value() == &a_vector);
+    }
+
+    SECTION("by const reference") {
+        auto int_rv = detail_::wrap_args_(std::as_const(an_int));
+        REQUIRE(std::get<0>(int_rv).value() == 1);
+        REQUIRE(&std::get<0>(int_rv).value() == &an_int);
+
+        auto vector_rv = detail_::wrap_args_(std::as_const(a_vector));
+        REQUIRE(std::get<0>(vector_rv).value() == a_vector);
+        REQUIRE(&std::get<0>(vector_rv).value() == &a_vector);
+    }
+
+    SECTION("by rvalue reference") {
+        auto vector_rv = detail_::wrap_args_(std::move(a_vector));
+        REQUIRE(std::get<0>(vector_rv).value().data() == pa_vector);
+    }
+}
+
+TEST_CASE("apply_") {
+    vector_type a_vector{1, 2, 3};
+    auto pa_vector = a_vector.data();
+
+    SECTION("Function takes no arguments") {
+        auto inputs = detail_::wrap_args_();
+        auto lambda = []() {};
+        REQUIRE_NOTHROW(detail_::apply_(lambda, std::move(inputs)));
+    }
+
+    SECTION("Function takes by value and passed by value") {
+        auto inputs = detail_::wrap_args_(vector_type{1, 2, 3});
+        auto lambda = [&a_vector](vector_type x) { REQUIRE(x == a_vector); };
+        REQUIRE_NOTHROW(detail_::apply_(lambda, std::move(inputs)));
+    }
+
+    SECTION("Function takes by value and passed by reference") {
+        auto inputs = detail_::wrap_args_(a_vector);
+        auto lambda = [&a_vector](vector_type x) {
+            REQUIRE(x == a_vector);
+            REQUIRE(x.data() != a_vector.data());
+        };
+        REQUIRE_NOTHROW(detail_::apply_(lambda, std::move(inputs)));
+    }
+
+    SECTION("Function takes by value and passed by const reference") {
+        auto inputs = detail_::wrap_args_(std::as_const(a_vector));
+        auto lambda = [&a_vector](vector_type x) {
+            REQUIRE(x == a_vector);
+            REQUIRE(x.data() != a_vector.data());
+        };
+        REQUIRE_NOTHROW(detail_::apply_(lambda, std::move(inputs)));
+    }
+
+    SECTION("Function takes by value and passed by rvalue") {
+        auto inputs = detail_::wrap_args_(std::move(a_vector));
+        auto lambda = [pa_vector](vector_type x) {
+            REQUIRE(x.data() == pa_vector);
+        };
+        REQUIRE_NOTHROW(detail_::apply_(lambda, std::move(inputs)));
+    }
+
+    // Should raise a compiler error
+    // SECTION("Function takes by reference and passed by value") {
+    //    auto inputs = detail_::wrap_args_(vector_type{1, 2, 3});
+    //    auto lambda = [&a_vector](vector_type& x) { };
+    //    REQUIRE_NOTHROW(detail_::apply_(lambda, std::move(inputs)));
+    //}
+
+    SECTION("Function takes by reference and passed by reference") {
+        auto inputs = detail_::wrap_args_(a_vector);
+        auto lambda = [&a_vector](vector_type& x) { REQUIRE(&x == &a_vector); };
+        REQUIRE_NOTHROW(detail_::apply_(lambda, std::move(inputs)));
+    }
+
+    // Should raise a compiler error
+    // SECTION("Function takes by reference and passed by const reference") {
+    //     auto inputs = detail_::wrap_args_(std::as_const(a_vector));
+    //     auto lambda = [&a_vector](vector_type& x) { };
+    //     REQUIRE_NOTHROW(detail_::apply_(lambda, std::move(inputs)));
+    // }
+
+    // Should raise a compiler error
+    // SECTION("Function takes by reference and passed by rvalue reference") {
+    //     auto inputs = detail_::wrap_args_(std::move(a_vector));
+    //    auto lambda = [pa_vector](vector_type& x) { };
+    //     REQUIRE_NOTHROW(detail_::apply_(lambda, std::move(inputs)));
+    // }
+
+    SECTION("Function takes by const reference and passed by value") {
+        auto inputs = detail_::wrap_args_(vector_type{1, 2, 3});
+        auto lambda = [&a_vector](const vector_type& x) {
+            REQUIRE(x == a_vector);
+        };
+        REQUIRE_NOTHROW(detail_::apply_(lambda, std::move(inputs)));
+    }
+
+    SECTION("Function takes by const reference and passed by reference") {
+        auto inputs = detail_::wrap_args_(a_vector);
+        auto lambda = [&a_vector](const vector_type& x) {
+            REQUIRE(&x == &a_vector);
+        };
+        REQUIRE_NOTHROW(detail_::apply_(lambda, std::move(inputs)));
+    }
+
+    SECTION("Function takes by const reference and passed by const reference") {
+        auto inputs = detail_::wrap_args_(std::as_const(a_vector));
+        auto lambda = [&a_vector](const vector_type& x) {
+            REQUIRE(&x == &a_vector);
+        };
+        REQUIRE_NOTHROW(detail_::apply_(lambda, std::move(inputs)));
+    }
+
+    SECTION(
+      "Function takes by const reference and passed by rvalue reference") {
+        auto inputs = detail_::wrap_args_(std::move(a_vector));
+        auto lambda = [pa_vector](const vector_type& x) {
+            REQUIRE(x.data() == pa_vector);
+        };
+        REQUIRE_NOTHROW(detail_::apply_(lambda, std::move(inputs)));
+    }
+
+    SECTION("Function takes by rvalue reference and passed by value") {
+        auto inputs = detail_::wrap_args_(vector_type{1, 2, 3});
+        auto lambda = [&a_vector](vector_type&& x) { REQUIRE(x == a_vector); };
+        REQUIRE_NOTHROW(detail_::apply_(lambda, std::move(inputs)));
+    }
+
+    // Should raise a compiler error
+    // SECTION("Function takes by rvalue reference and passed by reference") {
+    //     auto inputs = detail_::wrap_args_(a_vector);
+    //     auto lambda = [&a_vector](vector_type&& x) {};
+    //     REQUIRE_NOTHROW(detail_::apply_(lambda, std::move(inputs)));
+    // }
+
+    // Should raise a compiler error
+    // SECTION(
+    //   "Function takes by rvalue reference and passed by const reference") {
+    //     auto inputs = detail_::wrap_args_(std::as_const(a_vector));
+    //     auto lambda = [&a_vector](vector_type&& x) {};
+    //     REQUIRE_NOTHROW(detail_::apply_(lambda, std::move(inputs)));
+    // }
+
+    SECTION(
+      "Function takes by rvalue reference and passed by rvalue reference") {
+        auto inputs = detail_::wrap_args_(std::move(a_vector));
+        auto lambda = [pa_vector](vector_type&& x) {
+            REQUIRE(x.data() == pa_vector);
+        };
+        REQUIRE_NOTHROW(detail_::apply_(lambda, std::move(inputs)));
+    }
+
+    SECTION("Function returns by value") {
+        auto inputs = detail_::wrap_args_(std::move(a_vector));
+        auto lambda = [pa_vector](vector_type x) {
+            REQUIRE(x.data() == pa_vector);
+            return std::move(x);
+        };
+        auto rv = detail_::apply_(lambda, std::move(inputs));
+        REQUIRE(rv.data() == pa_vector);
+    }
+}

--- a/tests/cxx/unit_tests/parallelzone/task/detail_/task_wrapper_.cpp
+++ b/tests/cxx/unit_tests/parallelzone/task/detail_/task_wrapper_.cpp
@@ -198,3 +198,21 @@ TEST_CASE("apply_") {
         REQUIRE(rv.data() == pa_vector);
     }
 }
+
+TEST_CASE("make_inner_lambda_") {
+    // This function is largely implemented by wrap_args_ and apply_. As long
+    // as those two functions work this function should work. Point being we
+    // just spot check a round-trip of the input
+
+    vector_type a_vector{1, 2, 3};
+    auto pa_vector = a_vector.data();
+
+    auto lambda = [pa_vector](vector_type x) {
+        REQUIRE(x.data() == pa_vector);
+        return std::move(x);
+    };
+    auto lambda2 = detail_::make_inner_lambda_(lambda, std::move(a_vector));
+    REQUIRE(lambda2().data() == pa_vector);
+}
+
+TEST_CASE("make_outer_lambda_") {}

--- a/tests/cxx/unit_tests/parallelzone/task/detail_/task_wrapper_.cpp
+++ b/tests/cxx/unit_tests/parallelzone/task/detail_/task_wrapper_.cpp
@@ -208,7 +208,7 @@ TEST_CASE("apply_") {
         auto inputs = detail_::wrap_args_(std::move(a_vector));
         auto lambda = [pa_vector](vector_type x) {
             REQUIRE(x.data() == pa_vector);
-            return std::move(x);
+            return x;
         };
         auto rv = detail_::apply_(lambda, std::move(inputs));
         REQUIRE(rv.data() == pa_vector);
@@ -225,7 +225,7 @@ TEST_CASE("make_inner_lambda_") {
 
     auto lambda = [pa_vector](vector_type x) {
         REQUIRE(x.data() == pa_vector);
-        return std::move(x);
+        return x;
     };
     auto lambda2 = detail_::make_inner_lambda_(lambda, std::move(a_vector));
     REQUIRE(lambda2().data() == pa_vector);
@@ -249,7 +249,7 @@ TEST_CASE("make_outer_lambda_") {
     SECTION("Returns") {
         auto lambda = [pa_vector](vector_type x) {
             REQUIRE(x.data() == pa_vector);
-            return std::move(x);
+            return x;
         };
         auto lambda2 = detail_::make_outer_lambda_(lambda, std::move(a_vector));
         REQUIRE(std::any_cast<vector_type&&>(lambda2()).data() == pa_vector);

--- a/tests/cxx/unit_tests/parallelzone/task/detail_/task_wrapper_.cpp
+++ b/tests/cxx/unit_tests/parallelzone/task/detail_/task_wrapper_.cpp
@@ -231,4 +231,27 @@ TEST_CASE("make_inner_lambda_") {
     REQUIRE(lambda2().data() == pa_vector);
 }
 
-TEST_CASE("make_outer_lambda_") {}
+TEST_CASE("make_outer_lambda_") {
+    // This function is largely implemented by make_inner_lambda_. Here we just
+    // check it wraps the return correctly
+
+    vector_type a_vector{1, 2, 3};
+    auto pa_vector = a_vector.data();
+
+    SECTION("Doesn't return") {
+        auto lambda = [pa_vector](vector_type x) {
+            REQUIRE(x.data() == pa_vector);
+        };
+        auto lambda2 = detail_::make_outer_lambda_(lambda, std::move(a_vector));
+        REQUIRE_FALSE(lambda2().has_value());
+    }
+
+    SECTION("Returns") {
+        auto lambda = [pa_vector](vector_type x) {
+            REQUIRE(x.data() == pa_vector);
+            return std::move(x);
+        };
+        auto lambda2 = detail_::make_outer_lambda_(lambda, std::move(a_vector));
+        REQUIRE(std::any_cast<vector_type&&>(lambda2()).data() == pa_vector);
+    }
+}

--- a/tests/cxx/unit_tests/parallelzone/task/task_wrapper.cpp
+++ b/tests/cxx/unit_tests/parallelzone/task/task_wrapper.cpp
@@ -32,7 +32,7 @@ void no_return_free2(int* pv, vector_type v) { REQUIRE(v.data() == pv); }
 
 vector_type return_free2(int* pv, vector_type v) {
     REQUIRE(v.data() == pv);
-    return std::move(v);
+    return v;
 }
 
 struct TestFunctor {

--- a/tests/cxx/unit_tests/parallelzone/task/task_wrapper.cpp
+++ b/tests/cxx/unit_tests/parallelzone/task/task_wrapper.cpp
@@ -129,12 +129,22 @@ TEST_CASE("TaskWrapper") {
         };
 
         std::apply(tester, make_task(no_return_free0));
+
         std::apply(tester, make_task(no_return_free1, 1));
 
-        // This one makes sure that a moved object is forwarded all the way
-        // into the task.
         auto task = make_task(no_return_free2, pa_vector, std::move(a_vector));
-        // std::get<0>(task)();
-        //  std::apply(tester, std::move(task));
+        std::apply(tester, std::move(task));
+    }
+
+    SECTION("return") {
+        auto tester = [pa_vector](auto&& task, auto&& unwrapper) {
+            type_erased_return_type result;
+            REQUIRE_NOTHROW(result = task());
+            REQUIRE(result.has_value());
+            REQUIRE(unwrapper(std::move(result)).data() == pa_vector);
+        };
+
+        auto task = make_task(return_free2, pa_vector, std::move(a_vector));
+        std::apply(tester, std::move(task));
     }
 }

--- a/tests/cxx/unit_tests/parallelzone/task/task_wrapper.cpp
+++ b/tests/cxx/unit_tests/parallelzone/task/task_wrapper.cpp
@@ -1,0 +1,68 @@
+#include "../catch.hpp"
+#include <iostream>
+#include <parallelzone/task/task_wrapper.hpp>
+#include <vector>
+
+using namespace parallelzone::task;
+
+namespace {
+
+using vector_type = std::vector<int>;
+
+// Free functions with no returns and various inputs
+void no_return_free0() {}
+void no_return_free1(int) {}
+void no_return_free2(int* pv, vector_type v) { REQUIRE(v.data() == pv); }
+
+} // namespace
+
+using type_erased_return_type = TaskWrapper::type_erased_return_type;
+
+TEST_CASE("TaskWrapper") {
+    vector_type a_vector{1, 2, 3};
+    auto pa_vector = a_vector.data();
+
+    // SECTION("Constructor") {
+    //     TaskWrapper t(no_return_free2, pa_vector, std::move(a_vector));
+    //     // t();
+    // }
+
+    SECTION("unwrapper") {
+        SECTION("no result, i.e., void") {
+            auto u = TaskWrapper::unwrapper<void>();
+            std::any empty;
+            REQUIRE_NOTHROW(u(std::move(empty)));
+        }
+
+        SECTION("int") {
+            auto u      = TaskWrapper::unwrapper<int>();
+            auto da_any = std::make_any<int>(1);
+            REQUIRE(u(std::move(da_any)) == 1);
+        }
+
+        SECTION("vector") {
+            auto u      = TaskWrapper::unwrapper<vector_type>();
+            auto da_any = std::make_any<vector_type>(std::move(a_vector));
+            REQUIRE(std::any_cast<vector_type&>(da_any).data() == pa_vector);
+            REQUIRE(u(std::move(da_any)).data() == pa_vector);
+        }
+    }
+
+    SECTION("No return") {
+        auto tester = [](auto&& task, auto&& unwrapper) {
+            type_erased_return_type result;
+            REQUIRE_NOTHROW(result = task());
+            REQUIRE_FALSE(result.has_value());
+            REQUIRE_NOTHROW(unwrapper(std::move(result)));
+        };
+
+        std::apply(tester, make_task(no_return_free0));
+        std::apply(tester, make_task(no_return_free1, 1));
+
+        // This one makes sure that a moved object is forwarded all the way
+        // into the task.
+        auto task = make_task(no_return_free2, pa_vector, std::move(a_vector));
+        // std::get<0>(task)();
+        //  std::apply(tester, std::move(task));
+    }
+}


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
This PR is intended to add a function `profile` to the `CPU` class that takes a callable and
arguments for the callable, then the `CPU` object will run the callable while profiling it.
Well scope creep...now this PR will:

- [x] Introduce the task sub-library for type-erasing arbitrary function calls.
- [x] Introduce the `CPU` class (it didn't exist)
- [x] Add the `profile` function (as intended...)