### PR TITLE
Add separate workflow to manually trigger the CI tests on master

### DIFF
--- a/.github/workflows/run_tests_on_master.yaml
+++ b/.github/workflows/run_tests_on_master.yaml
@@ -1,0 +1,30 @@
+# Copyright 2025 NWChemEx-Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: .github Run tests on master
+
+on:
+  workflow_dispatch:  # Allow manually triggering the workflow
+
+jobs:
+  Common-Pull-Request:
+    uses: NWChemEx/.github/.github/workflows/common_pull_request.yaml@master
+    with:
+      # Don't add any license headers to files
+      config_file: ''
+      # Don't do any formatting on files
+      source_dir: ''
+      compilers: '["gcc-11", "clang-14"]'
+    secrets: inherit


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No.

**Description**
This PR adds a separate workflow that allows the CI tests to be manually triggered on the `master` branch at any time. While `workflow_dispatch:` could be added to the existing `.github/workflows/pull_request.yaml` workflow, that would also trigger unnecessary extra license header addition checks, formatting runs, and documentation builds. This separate action does not perform those extra actions (although some of those may be useful to manually trigger separately in the future).

**TODOs**
None.
