### PR TITLE
Use 'nwx_find_package' wrapper find MPI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ cmaize_find_or_build_dependency(
 )
 list(APPEND project_depends spdlog)
 
-# PAPI bindings are enabled, leading to building PAPI with CUDA or rocm support
+# PAPI bindings are enabled, leading to building PAPI with CUDA or ROCm support
 if("${BUILD_PAPI_BINDINGS}")
     include(build_papi)
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ project(parallelzone VERSION "${parallelzone_version}" LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 20)
 
 include(get_cmaize)
+include(nwx_find_package)
 
 # Work out the project paths
 set(project_inc_dir "${CMAKE_CURRENT_LIST_DIR}/include/${PROJECT_NAME}")
@@ -49,9 +50,14 @@ if (BUILD_CUDA_BINDING OR BUILD_HIP_BINDINGS OR BUILD_SYCL_BINDING)
 endif()
 
 ### Dependendencies ###
-set(project_depends "MPI::MPI_CXX")
 
-find_package(MPI REQUIRED)
+nwx_find_package(
+    MPI
+    REQUIRED
+    TARGETS
+        mpi "MPI::MPI_CXX"
+)
+set(project_depends mpi)
 
 cmaize_find_or_build_dependency(
     spdlog

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,3 @@
-sphinx
+sphinx<9
 sphinx_rtd_theme
 sphinx_tabs


### PR DESCRIPTION
## Description

This PR utilizes the find_package wrappers added by https://github.com/NWChemEx/NWXCMake/pull/59 to find MPI's `MPI::MPI_CXX` target.

## TODOs

- [x] Verify that it works when built independently
- [x] Verify that it works when built in Spack
